### PR TITLE
Add vue credential repository.

### DIFF
--- a/angular-credential-issuer/lib/config.js
+++ b/angular-credential-issuer/lib/config.js
@@ -25,6 +25,6 @@ config.views.system.packages.push({
 
 // URLs for Authorization.io
 cc('views.vars.authorization-io.baseUri', () =>
-  'https://authorization.localhost:33443');
-//  'https://demo.authorization.io');
+//  'https://authorization.localhost:33443');
+  'https://demo.authorization.io');
 //  config['did-client']['authorization-io'].baseUrl);

--- a/angular-credential-issuer/lib/config.js
+++ b/angular-credential-issuer/lib/config.js
@@ -25,5 +25,6 @@ config.views.system.packages.push({
 
 // URLs for Authorization.io
 cc('views.vars.authorization-io.baseUri', () =>
-  'https://demo.authorization.io');
+  'https://authorization.localhost:33443');
+//  'https://demo.authorization.io');
 //  config['did-client']['authorization-io'].baseUrl);

--- a/angular-credential-repository/lib/config.js
+++ b/angular-credential-repository/lib/config.js
@@ -25,6 +25,6 @@ config.views.system.packages.push({
 
 // URLs for Authorization.io
 cc('views.vars.authorization-io.baseUri', () =>
-  'https://authorization.localhost:33443');
-//  'https://demo.authorization.io');
+//  'https://authorization.localhost:33443');
+  'https://demo.authorization.io');
 //  config['did-client']['authorization-io'].baseUrl);

--- a/angular-credential-repository/lib/config.js
+++ b/angular-credential-repository/lib/config.js
@@ -25,5 +25,6 @@ config.views.system.packages.push({
 
 // URLs for Authorization.io
 cc('views.vars.authorization-io.baseUri', () =>
-  'https://demo.authorization.io');
+  'https://authorization.localhost:33443');
+//  'https://demo.authorization.io');
 //  config['did-client']['authorization-io'].baseUrl);

--- a/angular-credential-verifier/lib/config.js
+++ b/angular-credential-verifier/lib/config.js
@@ -25,7 +25,7 @@ config.views.system.packages.push({
 
 // URLs for Authorization.io
 cc('views.vars.authorization-io.baseUri', () =>
-  'https://authorization.localhost:33443');
-//  'https://demo.authorization.io');
+//  'https://authorization.localhost:33443');
+  'https://demo.authorization.io');
 //  config['did-client']['authorization-io'].baseUrl);
 

--- a/angular-credential-verifier/lib/config.js
+++ b/angular-credential-verifier/lib/config.js
@@ -25,6 +25,7 @@ config.views.system.packages.push({
 
 // URLs for Authorization.io
 cc('views.vars.authorization-io.baseUri', () =>
-  'https://demo.authorization.io');
+  'https://authorization.localhost:33443');
+//  'https://demo.authorization.io');
 //  config['did-client']['authorization-io'].baseUrl);
 

--- a/vue-credential-repository/README.md
+++ b/vue-credential-repository/README.md
@@ -1,0 +1,3 @@
+# vue-credential-repository
+
+TODO

--- a/vue-credential-repository/components/BrRoot.vue
+++ b/vue-credential-repository/components/BrRoot.vue
@@ -1,0 +1,53 @@
+<template>
+  <q-layout>
+
+    <q-layout-header>
+      <q-toolbar>
+        <q-btn
+          flat round dense
+          @click="showDrawer = !showDrawer"
+          icon="fa-bars"
+        />
+        <q-toolbar-title @click.native="goHome()">
+          Credential Wallet
+          <span slot="subtitle">Demo</span>
+        </q-toolbar-title>
+      </q-toolbar>
+    </q-layout-header>
+
+    <q-layout-drawer side="left" v-model="showDrawer">
+      <q-list no-border link inset-separator>
+        <q-list-header>Navigation</q-list-header>
+        <q-item to="/">
+          <q-item-side icon="fa-home" />
+          <q-item-main label="Home" />
+        </q-item>
+      </q-list>
+    </q-layout-drawer>
+
+    <q-page-container>
+      <router-view/>
+    </q-page-container>
+
+    <q-layout-footer>
+    </q-layout-footer>
+
+  </q-layout>
+</template>
+<script>
+export default {
+  name: 'BrRoot',
+  data() {
+    return {
+      showDrawer: false
+    };
+  },
+  methods: {
+    goHome() {
+      this.$router.push({path: '/'});
+    }
+  }
+};
+</script>
+<style>
+</style>

--- a/vue-credential-repository/components/CredentialCard.vue
+++ b/vue-credential-repository/components/CredentialCard.vue
@@ -1,0 +1,206 @@
+<template>
+  <div class="row" style="margin: 0;">
+    <div class="br-card-id-1 br-card-id-1-border" xstyle="cardStyle">
+      <div class="br-credential-card-header" align="center">
+        {{credential.name | uppercase}}
+      </div>
+      <div class="br-credential-card-body">
+        <div class="br-credential-card-body-col-1">
+          <div class="br-credential-card-picture">
+            <img :src="credential.image">
+          </div>
+        </div>
+        <div class="br-credential-card-body-col-2">
+          <div class="br-passport-row-1-col-1">
+            <dl class="br-credential-card-attr">
+              <dt>Name</dt>
+              <dd>{{credential.claim.name | uppercase}}</dd>
+              <dt>Gender</dt>
+              <dd>
+                {{credential.claim['schema:gender'] | uppercase}}
+              </dd>
+              <dt>Date of birth</dt>
+              <dd>
+                {{credential.claim['schema:birthDate']['@value'] | date:'MM/dd/yyyy'}}
+              </dd>
+              <dt>Nationality</dt>
+              <dd>{{credential.claim['schema:nationality'].name | uppercase}}</dd>
+            </dl>
+          </div>
+          <div class="br-passport-row-1-col-2">
+            <dl class="br-credential-card-attr">
+              <dt>Height</dt>
+              <dd>{{credential.claim['schema:height']}}</dd>
+              <dt>Eye Color</dt>
+              <dd>
+                {{credential.claim['urn:bedrock:test:eyeColor'] | uppercase}}
+              </dd>
+            </dl>
+          </div>
+          <div class="br-passport-row-1-col-3">
+            <img :src="credential.claim.image">
+          </div>
+          <div class="br-passport-row-2">
+            <dl class="br-credential-card-attr">
+              <dt>Address</dt>
+              <dd>
+                <div>{{credential.claim.address.streetAddress | uppercase}}</div>
+                <div>{{credential.claim.address.addressLocality | uppercase}},
+                  {{credential.claim.address.addressRegion | uppercase}}
+                  {{credential.claim.address.postalCode | uppercase}} {{credential.claim.address.addressCountry | uppercase}}</div>
+              </dd>
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+<script>
+/*!
+ * New BSD License (3-clause)
+ * Copyright (c) 2017-2018, Digital Bazaar, Inc.
+ * All rights reserved.
+ */
+'use strict';
+
+export default {
+  name: 'CredentialCard',
+  props: {
+    credential: {
+      type: Object,
+      required: true
+    },
+    cardWidth: {
+      type: String,
+      default: '300px'
+    },
+    cardBackgroundColor: String,
+    cardBackgroundImage: String
+  },
+  /*data() {
+    return {
+      credential2: { "@context": [ "https://w3id.org/identity/v1", "https://w3id.org/credentials/v1", { "br": "urn:bedrock:" } ], "id": "did:method1:1234-1234-1234-1234", "credential": [ { "@graph": { "@context": [ "https://w3id.org/identity/v1", "https://w3id.org/credentials/v1", { "br": "urn:bedrock:" } ], "id": "urn:uuid:a4cbc46c-19bf-4966-8db6-2f164ec97fb9", "type": [ "Credential", "br:test:PassportCredential" ], "name": "Passport", "issued": "2018-07-13T19:48:48.965Z", "issuer": "urn:issuer:test", "image": "http://simpleicon.com/wp-content/uploads/global_1-128x128.png", "claim": { "id": "did:method1:1234-1234-1234-1234", "name": "Pat Doe", "image": "http://simpleicon.com/wp-content/uploads/business-woman-2-128x128.png", "schema:birthDate": { "@value": "1980-01-01T00:00:00Z", "@type": "xsd:dateTime" }, "schema:gender": "female", "schema:height": "65in", "br:test:eyeColor": "blue", "schema:nationality": { "name": "United States" }, "address": { "type": "PostalAddress", "streetAddress": "1 Main St.", "addressLocality": "Blacksburg", "addressRegion": "Virginia", "postalCode": "24060", "addressCountry": "US" }, "br:test:passport": { "type": "br:test:Passport", "name": "Test Passport", "br:test:documentId": "1531511328965", "issuer": "https://example.gov/", "issued": "2010-01-07T01:02:03Z", "expires": "2020-01-07T01:02:03Z" } }, "signature": { "type": "RsaSignature2017", "created": "2017-08-09T01:02:03Z", "creator": "did:db0f0ccd-2062-4b7b-8cbd-bb14d50769b0/keys/1", "signatureValue": "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz01234567890ABCDEFGHIJKLM==" } } } ] }
+    };
+  },*/
+  computed: {
+    cardStyle() {
+      return computeCardStyle({width: this.cardWidth});
+    },
+    /*
+    // FIXME: remove me
+    credential() {
+      console.log('this.credential2', this.credential2)
+      return this.credential2.credential[0]['@graph'];
+    }*/
+  },
+  filters: {
+    uppercase: value => (value || '').toUpperCase()
+  }
+};
+
+/**
+ * Computes the CSS style for a ISO/IEC 7810 ID-1 card based on the given
+ * displayer options.
+ *
+ * @param type the type of card (default: 'id-1').
+ * @param [width] the width for the card component.
+ * @param [background] an object with the background style to use.
+ *
+ * @return the computed style.
+ */
+function computeCardStyle({type = 'id-1', width = '300px', background}) {
+  const style = {};
+
+  if(type !== 'id-1') {
+    throw new TypeError(
+      'Unsupported card type: "' + type +
+      '". Supported types are: "id-1".');
+  }
+
+  if(typeof width === 'string') {
+    const width = parseCssValue(width);
+    style.width = width;
+    // id-1 dimensions are 85.60mm x 53.98mm
+    style.height = (width.value * 53.98 / 85.60) + width.unit;
+    // default CSS is coded based on a 1/100 width:fontsize ratio
+    style['font-size'] = (width.value * 1 / 100) + width.unit;
+  }
+
+  // TODO: need to be able to support different backgrounds for card header
+  // vs. card body
+  if(background && typeof background === 'object') {
+    Object.assign(style, computeBackground(background));
+  }
+
+  return style;
+}
+
+/**
+ * Computes the CSS style for an element's background.
+ *
+ * @param [color] the CSS color.
+ * @param [image] the image as a URL.
+ * @param [linearGradient] true for a default linear gradient.
+ * @param [radialGradient] true for a default radial gradient.
+ *
+ * @return the computed style.
+ */
+function computeBackground({color, image, linearGradient, radialGradient}) {
+  const style = {};
+
+  if(color) {
+    style['background-color'] = color;
+  }
+
+  const backgroundImages = [];
+  if(image) {
+    backgroundImages.push('url("' + image + '")');
+  }
+
+  if(radialGradient === true) {
+    // create default radial gradient
+    radialGradient = 'radial-gradient(' +
+      'circle at -25% -25%, ' +
+      'rgba(255, 255, 255, 0.75) 0%, ' +
+      'transparent 70%, ' +
+      'rgba(0, 0, 0, 0.2) 90%)';
+    /* radialGradient = 'radial-gradient(' +
+      'ellipse at center, #fff 0%, transparent 80%)';*/
+  }
+  if(radialGradient) {
+    backgroundImages.push(radialGradient);
+  }
+
+  if(linearGradient === true) {
+    // create default linear gradient
+    linearGradient = 'linear-gradient(' +
+      'to bottom right, ' +
+      'rgba(255, 255, 255, 0.5) 0%, ' +
+      'transparent 40%, ' +
+      'rgba(0, 0, 0, 0.2) 80%)';
+    backgroundImages.push(linearGradient);
+  }
+
+  if(backgroundImages.length > 0) {
+    style['background-image'] = backgroundImages.join(', ');
+  }
+
+  return style;
+}
+
+function parseCssValue(value) {
+  const parsed = {};
+  const matches = value.toString().trim().match(/^(-?[\d+\.\-]+)([a-z]+|%)$/i);
+  if(matches) {
+    parsed.value = parseFloat(matches[1]);
+    parsed.unit = matches[2];
+  } else {
+    parsed.value = 0;
+    parsed.unit = value;
+  }
+  return parsed;
+}
+</script>
+<style>
+</style>

--- a/vue-credential-repository/components/CredentialCard.vue
+++ b/vue-credential-repository/components/CredentialCard.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="row" style="margin: 0;">
-    <div class="br-card-id-1 br-card-id-1-border" xstyle="cardStyle">
+    <div class="br-card-id-1 br-card-id-1-border" :style="cardStyle">
       <div class="br-credential-card-header" align="center">
         {{credential.name | uppercase}}
       </div>
@@ -78,21 +78,10 @@ export default {
     cardBackgroundColor: String,
     cardBackgroundImage: String
   },
-  /*data() {
-    return {
-      credential2: { "@context": [ "https://w3id.org/identity/v1", "https://w3id.org/credentials/v1", { "br": "urn:bedrock:" } ], "id": "did:method1:1234-1234-1234-1234", "credential": [ { "@graph": { "@context": [ "https://w3id.org/identity/v1", "https://w3id.org/credentials/v1", { "br": "urn:bedrock:" } ], "id": "urn:uuid:a4cbc46c-19bf-4966-8db6-2f164ec97fb9", "type": [ "Credential", "br:test:PassportCredential" ], "name": "Passport", "issued": "2018-07-13T19:48:48.965Z", "issuer": "urn:issuer:test", "image": "http://simpleicon.com/wp-content/uploads/global_1-128x128.png", "claim": { "id": "did:method1:1234-1234-1234-1234", "name": "Pat Doe", "image": "http://simpleicon.com/wp-content/uploads/business-woman-2-128x128.png", "schema:birthDate": { "@value": "1980-01-01T00:00:00Z", "@type": "xsd:dateTime" }, "schema:gender": "female", "schema:height": "65in", "br:test:eyeColor": "blue", "schema:nationality": { "name": "United States" }, "address": { "type": "PostalAddress", "streetAddress": "1 Main St.", "addressLocality": "Blacksburg", "addressRegion": "Virginia", "postalCode": "24060", "addressCountry": "US" }, "br:test:passport": { "type": "br:test:Passport", "name": "Test Passport", "br:test:documentId": "1531511328965", "issuer": "https://example.gov/", "issued": "2010-01-07T01:02:03Z", "expires": "2020-01-07T01:02:03Z" } }, "signature": { "type": "RsaSignature2017", "created": "2017-08-09T01:02:03Z", "creator": "did:db0f0ccd-2062-4b7b-8cbd-bb14d50769b0/keys/1", "signatureValue": "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz01234567890ABCDEFGHIJKLM==" } } } ] }
-    };
-  },*/
   computed: {
     cardStyle() {
       return computeCardStyle({width: this.cardWidth});
-    },
-    /*
-    // FIXME: remove me
-    credential() {
-      console.log('this.credential2', this.credential2)
-      return this.credential2.credential[0]['@graph'];
-    }*/
+    }
   },
   filters: {
     uppercase: value => (value || '').toUpperCase()
@@ -119,7 +108,7 @@ function computeCardStyle({type = 'id-1', width = '300px', background}) {
   }
 
   if(typeof width === 'string') {
-    const width = parseCssValue(width);
+    width = parseCssValue(width);
     style.width = width;
     // id-1 dimensions are 85.60mm x 53.98mm
     style.height = (width.value * 53.98 / 85.60) + width.unit;

--- a/vue-credential-repository/components/CredentialRequest.vue
+++ b/vue-credential-repository/components/CredentialRequest.vue
@@ -1,0 +1,144 @@
+<template>
+  <q-page
+    class="column gutter-lg"
+    style="background-color: white; height: 100vh"
+    padding>
+    <div v-if="loading" class="row">
+      <span>Loading credential request details...</span>
+    </div>
+    <div v-else-if="credential" class="column gutter-sm">
+      <div class="row justify-center">Do you want to send these credentials?</div>
+      <div class="row justify-center">
+        <credential-card :credential="credential" />
+        <!-- div>{{credential}}</div -->
+      </div>
+      <div class="row justify-center">
+        <q-btn
+          class="q-mr-sm"
+          icon="fa-times"
+          color="red"
+          :disabled="loading"
+          label="No"
+          @click="cancel()" />
+        <q-btn
+          icon="fa-check"
+          color="green"
+          :disabled="loading"
+          label="Yes"
+          @click="send()" />
+      </div>
+    </div>
+    <div v-else class="row">
+      <div>You do not have the credentials required by the verifier. Make
+        sure you visit the demo issuer website prior to using this
+        identity.</div>
+      <q-btn icon="fa-times" color="primary" :disabled="loading"
+        label="Ok" @click="cancel()"/>
+    </div>
+    <div class="row justify-center">
+      <p>
+        This is a credential repository (aka wallet) demonstration website. It
+        has been loaded during a credential request from a credential verifier
+        website.
+        <a href="" @click.stop.prevent="showDetails=!showDetails">Show technical details</a>
+      </p>
+    </div>
+    <div v-if="showDetails" class="row col justify-center">
+      <p>This website uses the Credential Handler API polyfill. It calls
+      code that looks like this to receive a credential request:</p>
+      <pre>
+        const handler = new CredentialHandler(MEDIATOR_ORIGIN);
+
+        handler.addEventListener('credentialrequest', event => {
+          event.respondWith(new Promise(async (resolve, reject) => {
+            window.addEventListener('message', e => {
+              // wait for message from the window we opened with
+              // credential choice
+              resolve(e.data.credential);
+            });
+
+            // open a window (with the content you see above)
+            const windowClient = await event.openWindow('/credentialrequest');
+          }));
+        });
+      </pre>
+    </div>
+  </q-page>
+</template>
+<script>
+/*!
+ * New BSD License (3-clause)
+ * Copyright (c) 2017-2018, Digital Bazaar, Inc.
+ * All rights reserved.
+ */
+'use strict';
+
+import localforage from 'localforage';
+import CredentialCard from './CredentialCard.vue';
+
+export default {
+  name: 'CredentialRequest',
+  components: {CredentialCard},
+  mounted() {
+    const self = this;
+    self.loading = true;
+
+    window.addEventListener('message', async event => {
+      console.log('UI window got credential request', event.data);
+      self.credentialRequestOptions = event.data.credentialRequestOptions;
+      self.domain = event.data.credentialRequestOrigin;
+      const storage = localforage.createInstance({name: 'credentials'});
+      self.credential = await storage.getItem(event.data.hintKey);
+      self.loading = false;
+    });
+
+    // request credential request
+    window.parent.postMessage({type: 'request'}, window.location.origin);
+
+    console.log('loaded credential request UI');
+  },
+  data() {
+    return {
+      loading: true,
+      credential: null,
+      domain: '',
+      credentialRequestOptions: null,
+      showDetails: false
+    };
+  },
+  methods: {
+    cancel() {
+      this.loading = true;
+      window.parent.postMessage({
+        type: 'response',
+        credential: null
+      }, window.location.origin);
+    },
+    send() {
+      this.loading = true;
+      window.parent.postMessage({
+        type: 'response',
+        credential: {
+          dataType: 'VerifiableProfile',
+          data: {
+            '@context': 'https://w3id.org/credentials/v1',
+            id: this.credential.claim.id,
+            credential: [{
+              '@graph': this.credential
+            }],
+            signature: {
+              type: 'RsaSignature2017',
+              created: '2017-08-09T01:02:03Z',
+              creator: 'did:736f1d73-f1d8-42bb-9145-3e30062fbd15/keys/1',
+              domain: this.domain,
+              signatureValue: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz01234567890ABCDEFGHIJKLM=='
+            }
+          }
+        }
+      }, window.location.origin);
+    }
+  }
+};
+</script>
+<style>
+</style>

--- a/vue-credential-repository/components/CredentialStore.vue
+++ b/vue-credential-repository/components/CredentialStore.vue
@@ -1,0 +1,124 @@
+<template>
+  <q-page
+    class="column gutter-lg"
+    style="background-color: white; height: 100vh"
+    padding>
+    <div v-if="loading" class="row">
+      <span>Loading credential request details...</span>
+    </div>
+    <div v-else-if="profile" class="column gutter-sm">
+      <div class="row justify-center">Do you want to store these credentials?</div>
+      <div class="row justify-center">
+        <credential-card :credential="credential" />
+        <!-- div>{{profile}}</div -->
+      </div>
+      <div class="row justify-center">
+        <q-btn
+          class="q-mr-sm"
+          icon="fa-times"
+          color="red"
+          :disabled="loading"
+          label="No"
+          @click="cancel()" />
+        <q-btn
+          icon="fa-check"
+          color="green"
+          :disabled="loading"
+          label="Yes"
+          @click="store()" />
+      </div>
+    </div>
+    <div class="row justify-center">
+      <p>
+        This is a credential repository (aka wallet) demonstration website. It
+        has been loaded during a credential request from a credential verifier
+        website.
+        <a href="" @click.stop.prevent="showDetails=!showDetails">Show technical details</a>
+      </p>
+    </div>
+    <div v-if="showDetails" class="row col justify-center">
+      <p>This website uses the Credential Handler API polyfill. It calls
+      code that looks like this to receive a credential storage request:</p>
+      <pre>
+        const handler = new CredentialHandler(MEDIATOR_ORIGIN);
+
+        handler.addEventListener('credentialstore', event => {
+          event.respondWith(new Promise(async (resolve, reject) => {
+            window.addEventListener('message', e => {
+              // wait for message from the window we opened with what was stored
+              resolve(e.data.credential);
+            });
+
+            // open a window (with the content you see above)
+            const windowClient = await event.openWindow('/credentialstore');
+          }));
+        });
+      </pre>
+    </div>
+  </q-page>
+</template>
+<script>
+/*!
+ * New BSD License (3-clause)
+ * Copyright (c) 2017-2018, Digital Bazaar, Inc.
+ * All rights reserved.
+ */
+'use strict';
+
+import localforage from 'localforage';
+import CredentialCard from './CredentialCard.vue';
+
+export default {
+  name: 'CredentialStore',
+  components: {CredentialCard},
+  mounted() {
+    const self = this;
+    self.loading = true;
+
+    window.addEventListener('message', async event => {
+      console.log('UI window got credential storage request', event.data);
+      self.profile = event.data.credential.data;
+      self.credential = self.profile.credential[0]['@graph'];
+      console.log('credential', self.credential);
+      self.loading = false;
+    });
+
+    // request storage request
+    window.parent.postMessage({type: 'request'}, window.location.origin);
+
+    console.log('loaded credential storage UI');
+  },
+  data() {
+    return {
+      loading: true,
+      credential: null,
+      profile: null,
+      showDetails: false
+    };
+  },
+  methods: {
+    cancel() {
+      this.loading = true;
+      window.parent.postMessage({
+        type: 'response',
+        credential: null
+      }, window.location.origin);
+    },
+    async store() {
+      this.loading = true;
+      const storage = localforage.createInstance({name: 'credentials'});
+      await storage.setItem(this.profile.id, this.credential);
+
+      window.parent.postMessage({
+        type: 'response',
+        credential: {
+          dataType: 'VerifiableProfile',
+          data: this.profile
+        }
+      }, window.location.origin);
+    }
+  }
+};
+</script>
+<style>
+</style>

--- a/vue-credential-repository/components/Home.vue
+++ b/vue-credential-repository/components/Home.vue
@@ -1,0 +1,230 @@
+<template>
+  <q-page
+    class="column gutter-md"
+    style="background-color: white; height: 100vh"
+    padding>
+    <div class="row justify-center">
+      <div>
+        <h4 class="text-center">Credential Handler</h4>
+        <div class="row justify-center gutter-sm">
+          <q-btn
+            class="q-mr-sm"
+            color="primary"
+            :disabled="installed"
+            label="Install"
+            @click="install()" />
+          <q-btn
+            color="red"
+            :disabled="!installed"
+            label="Uninstall"
+            @click="uninstall()" />
+        </div>
+      </div>
+    </div>
+    <div v-if="installed" class="row justify-center">
+      <div style="border: 1px solid lightgray; padding: 20px">
+        <i class="fa fa-check fa-lg" style="color: green; vertical-align: 0; margin-right: 5px"></i>
+        <span style="font-size: 20px">Credential handler installed! Three
+        demo identities have been added. Please
+        visit the <a href="https://credential-issuer.demo.digitalbazaar.com">Example Credential Issuer</a>
+        to receive a demo credential.</span>
+      </div>
+    </div>
+    <div class="row justify-center">
+      This is a credential repository (aka wallet) demonstration website. It
+      allows you to register a "credential handler" that can handle credential
+      requests and credential storage requests from other websites.
+    </div>
+    <div class="row justify-center">
+      <a href="" @click.stop.prevent="showDetails=!showDetails">Show technical details</a>
+    </div>
+    <div v-if="showDetails" class="row col justify-center">
+      <p>This website uses the Credential Handler API polyfill. It calls
+      code that looks like this to add choices for users to select to fulfill
+      requests for credentials:</p>
+      <pre>
+      async function install() {
+        const result = await CredentialManager.requestPermission();
+        if(result !== 'granted') {
+          throw new Error('Permission denied.');
+          return;
+        }
+
+        // get credential handler registration
+        const registration = await CredentialHandlers.register(
+          '/credential-handler');
+
+        await addHints(registration);
+      }
+
+      function addHints(registration) {
+        return Promise.all([
+          registration.credentialManager.hints.set(
+            // this could be a UUID or any 'key'
+            // understood by this wallet
+            'default',
+            {
+              name: 'One of my many identities',
+              enabledTypes: ['VerifiableProfile'],
+              match: {
+                VerifiableProfile: {
+                  id: 'did:method1:1234-1234-1234-1234'
+                }
+              }
+            })
+          ]);
+      }
+      </pre>
+    </div>
+  </q-page>
+</template>
+<script>
+/*!
+ * New BSD License (3-clause)
+ * Copyright (c) 2017-2018, Digital Bazaar, Inc.
+ * All rights reserved.
+ */
+'use strict';
+
+export default {
+  name: 'Home',
+  async mounted() {
+    try {
+      const registration = await getRegistration();
+      await registration.credentialManager.hints.keys();
+      this.registration = registration;
+    } catch(e) {
+      // assume permission denied for demo
+    }
+    console.log('installed', !!this.registration);
+  },
+  data() {
+    return {
+      showDetails: false,
+      registration: null
+    };
+  },
+  computed: {
+    installed() {
+      return !!this.registration;
+    },
+    uninstalled() {
+      return !this.registration;
+    }
+  },
+  methods: {
+    async install() {
+      try {
+        this.registration = null;
+        this.registration = await install();
+      } catch(e) {
+        console.error('installation failed,', e);
+      }
+    },
+    async uninstall() {
+      try {
+        await uninstall();
+        this.registration = null;
+      } catch(e) {
+        console.error('uninstallation failed,', e);
+      }
+    }
+  }
+};
+
+async function getRegistration() {
+  const CredentialHandlers = navigator.credentialsPolyfill.CredentialHandlers;
+
+  let registration;
+  try {
+    // get credential handler registration
+    registration = await CredentialHandlers.register('/credential-handler');
+  } catch(e) {
+    // ignore
+    console.error(e);
+  }
+  return registration;
+}
+
+async function install() {
+  console.log('installing...');
+
+  // ensure permission has been granted to add a credential hint
+  const result = await CredentialManager.requestPermission();
+  if(result !== 'granted') {
+    throw new Error('Permission denied.');
+  }
+
+  // get credential handler registration
+  const registration = await getRegistration();
+  if(!registration) {
+    throw new Error('Credential handler not registered');
+  }
+
+  console.log('adding hints');
+  await addHints(registration);
+  console.log('credential hints added');
+
+  console.log('installation complete.');
+  return registration;
+}
+
+async function uninstall() {
+  console.log('uninstalling...');
+
+  const CredentialHandlers = navigator.credentialsPolyfill.CredentialHandlers;
+
+  // ensure permission has been granted to add a credential hint
+  const result = await CredentialManager.requestPermission();
+  if(result !== 'granted') {
+    throw new Error('Permission denied.');
+  }
+
+  // unregister credential handler registration
+  await CredentialHandlers.unregister('/credential-handler');
+  console.log('credential handler unregistered');
+
+  // revoke permission (useful for demonstration purposes)
+  await navigator.credentialsPolyfill.permissions.revoke(
+    {name: 'credentialhandler'});
+
+  console.log('uninstallation complete.');
+}
+
+async function addHints(registration) {
+  return Promise.all([
+    registration.credentialManager.hints.set(
+      'did:method1:1234-1234-1234-1234', {
+        name: 'My social wallet',
+        enabledTypes: ['VerifiableProfile'],
+        match: {
+          VerifiableProfile: {
+            id: 'did:method1:1234-1234-1234-1234'
+          }
+        }
+      }),
+    registration.credentialManager.hints.set(
+      'did:method1:1234-1234-1234-1235', {
+        name: 'My business wallet',
+        enabledTypes: ['VerifiableProfile'],
+        match: {
+          VerifiableProfile: {
+            id: 'did:method1:1234-1234-1234-1235'
+          }
+        }
+      }),
+    registration.credentialManager.hints.set(
+      'did:method1:1234-1234-1234-1236', {
+        name: 'My account for this website',
+        enabledTypes: ['VerifiableProfile'],
+        match: {
+          VerifiableProfile: {
+            id: 'did:method1:1234-1234-1234-1236'
+          }
+        }
+      })
+    ]);
+}
+</script>
+<style>
+</style>

--- a/vue-credential-repository/components/app.less
+++ b/vue-credential-repository/components/app.less
@@ -1,0 +1,9 @@
+@import "./card.less";
+
+@fa-font-path: "@{bedrock-module-path}/@fortawesome/fontawesome-free-webfonts/webfonts";
+@font-face {
+  font-family: "Open Sans";
+  font-style: normal;
+  font-weight: 800;
+  src: local("Open Sans ExtraBold"), local("OpenSans-ExtraBold"), url("https://fonts.gstatic.com/s/opensans/v14/EInbV5DfGHOiMmvb1Xr-hugdm0LZdjqr5-oayXSOefg.woff2") format("woff2"); unicode-range: U+0-FF, U+131, U+152-153, U+2C6, U+2DA, U+2DC, U+2000-206F, U+2074, U+20AC, U+2212, U+2215;
+}

--- a/vue-credential-repository/components/card.less
+++ b/vue-credential-repository/components/card.less
@@ -1,0 +1,186 @@
+@import 'https://fonts.googleapis.com/css?family=Alegreya:400i';
+@import 'https://fonts.googleapis.com/css?family=Kotta+One';
+@import 'https://fonts.googleapis.com/css?family=Open+Sans:800';
+@import 'https://fonts.googleapis.com/css?family=Roboto';
+@import 'https://fonts.googleapis.com/css?family=Roboto+Condensed';
+
+/* ISO/IEC 7810 ID-1 cards are 85.60 x 53.98 mm (3.370 x 2.125 in) with
+  rounded corners with a radius of 2.88–3.48 mm. Dimensions here are based
+  on 300px width for mobile devices (an iPhone 5 screen width is 320px, which
+  leaves room for up to 10px of margin). */
+@br-card-id-1-width-mm: 85.60;
+@br-card-id-1-height-mm: 53.98;
+@br-card-id-1-width: 300px;
+@br-card-id-1-height: (
+  (@br-card-id-1-height-mm / @br-card-id-1-width-mm) *
+  @br-card-id-1-width);
+/*@br-card-id-1-height: percentage(
+ (@br-card-id-1-height-mm / @br-card-id-1-width-mm));*/
+
+/* 1 inch = 25.4 mm */
+@br-card-id-1-inch: percentage((25.4 / @br-card-id-1-width-mm));
+
+/* Average of 2.88mm and 3.48mm, as a percentage of width, height. */
+@br-card-id-1-radius-mm: ((2.88 + 3.48) / 2);
+@br-card-id-1-radius-width: percentage(
+  (@br-card-id-1-radius-mm / @br-card-id-1-width-mm));
+@br-card-id-1-radius-height: percentage(
+  (@br-card-id-1-radius-mm / @br-card-id-1-height-mm));
+
+@br-card-id-1-card-border-size-mm: 0.6;
+@br-card-id-1-card-border-top: percentage(
+  (@br-card-id-1-card-border-size-mm / @br-card-id-1-height-mm));
+@br-card-id-1-card-border-left: percentage(
+  (@br-card-id-1-card-border-size-mm / @br-card-id-1-width-mm));
+
+@br-card-id-1-card-border-radius-width: (
+  @br-card-id-1-radius-width - @br-card-id-1-card-border-left);
+@br-card-id-1-card-border-radius-height: (
+  @br-card-id-1-radius-height - @br-card-id-1-card-border-top);
+
+@br-card-header-height: 17.5%;
+
+/* `width` can be dynamically set to scale card, but `font-size` must also be
+  set to 1/10th of `width`. Note: Presently, `height` must also be set to
+  53.98/85.6 times `width`. Some CSS-magic w/padding-top percentages could
+  potentially remove this additional calculation in the future. */
+.br-card-id-1 {
+  position: relative;
+  width: @br-card-id-1-width;
+  height: @br-card-id-1-height;
+  background-color: #eee;
+  border-radius: @br-card-id-1-radius-width ~'/'
+    @br-card-id-1-radius-height;
+  box-shadow: 4px 4px 4px rgba(0, 0, 0, 0.15);
+  margin: 0 4px 4px 0;
+  /*border: 1px solid #d0d0d0;*/
+  text-align: left;
+  box-sizing: border-box;
+  overflow: hidden;
+  font-size: (@br-card-id-1-width / 100);
+}
+/* card border */
+.br-card-id-1-border:before {
+  position: absolute;
+  content: '';
+  top: @br-card-id-1-card-border-top;
+  bottom: @br-card-id-1-card-border-top;
+  left: @br-card-id-1-card-border-left;
+  right: @br-card-id-1-card-border-left;
+  border-radius: @br-card-id-1-card-border-radius-width ~'/'
+    @br-card-id-1-card-border-radius-height;
+  /* dark shadow permeates outward, light shadow permeats inward creating
+    an edge effect */
+  box-shadow:
+    /* dark outward shadow lower right creates edge shadow */
+    30px 30px 100px 1px rgba(0, 0, 0, 0.2),
+    /* bright outward shadow upper left creates edge highlight */
+    -30px -30px 100px 1px rgba(255, 255, 255, 0.5),
+    /* bright inward shadow creates inner edge basis */
+    inset 0 0 2px 1px rgba(255, 255, 255, 0.25);
+}
+/* radial gradient */
+.br-card-id-1-radial-gradient:after {
+	position: absolute;
+  content: '';
+	top: 0;
+	right: 0;
+	bottom: 0;
+	left: 0;
+	background-image: radial-gradient(
+	  circle at -25% -25%,
+	  rgba(255, 255, 255, 0.74902) 0%,
+	  transparent 70%,
+	  rgba(0, 0, 0, 0.2) 90%);
+}
+
+.br-text-ellipsis {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+.br-scale-text-wide {
+  display: inline-block;
+  -webkit-transform:scale(1.5, 1.0);
+  -moz-transform:scale(1.5, 1.0);
+  -ms-transform:scale(1.5, 1.0);
+  -o-transform:scale(1.5, 1.0);
+  transform:scale(1.5, 1.0);
+}
+
+.br-credential-card-header {
+  color: black;
+  height: @br-card-header-height;
+  padding-top: 1%;
+  background-color: rgba(144, 167, 253, 0.25);
+  border-bottom: 2px solid #809ded;
+  font-family: 'Roboto', sans-serif;
+  font-size: 6em;
+  font-weight: bold;
+  color: #4786e4;
+  text-shadow: 1px 1px 1px #2f5a9a;
+  -webkit-font-smoothing: antialiased;
+}
+.br-credential-card-body {
+  width: 100%;
+  height: (100% - @br-card-header-height);
+  background-color: rgba(184, 219, 255, 0.1);
+}
+.br-credential-card-body-col-1 {
+  width: @br-card-id-1-inch;
+  display: inline-block;
+}
+.br-credential-card-body-col-2 {
+  width: (100% - @br-card-id-1-inch);
+  display: inline-block;
+  float: right;
+  padding-top: 4px;
+  padding-left: 2px;
+}
+.br-credential-card-picture {
+  height: 64%;
+}
+.br-credential-card-picture > img {
+  width: 100%;
+  height: auto;
+  margin-top: 2px;
+  padding: 1px;
+}
+dl.br-credential-card-attr {
+  margin-bottom: 3.5%;
+}
+dl.br-credential-card-attr > dt {
+  font-family: 'Kotta One', serif;
+  font-size: 2em;
+  color: #555;
+}
+dl.br-credential-card-attr > dd {
+  font-family: 'Open Sans', sans-serif;
+  font-weight: bold;
+  font-size: 2.75em;
+  color: #111;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
+.br-passport-row-1-col-1 {
+  display: inline-block;
+  vertical-align: top;
+}
+.br-passport-row-1-col-2 {
+  display: inline-block;
+  vertical-align: top;
+}
+.br-passport-row-1-col-3 {
+  width: @br-card-id-1-inch;
+  display: inline-block;
+  float: right;
+  vertical-align: top;
+}
+.br-passport-row-1-col-3 > img {
+  width: 100%;
+  height: auto;
+}
+.br-passport-row-2 {
+  width: 100%;
+}

--- a/vue-credential-repository/components/credential-handler.js
+++ b/vue-credential-repository/components/credential-handler.js
@@ -1,0 +1,83 @@
+/*!
+ * Copyright (c) 2017 Digital Bazaar, Inc. All rights reserved.
+ */
+/* global navigator */
+'use strict';
+
+export async function activate(mediatorOrigin) {
+  console.log('credential handler activating!');
+  const CredentialHandler = navigator.credentialsPolyfill.CredentialHandler;
+  const self = new CredentialHandler(mediatorOrigin);
+
+  self.addEventListener('credentialrequest', handleCredentialEvent)
+  self.addEventListener('credentialstore', handleCredentialEvent);
+
+  await self.connect();
+  console.log('credential handler connected');
+}
+
+function handleCredentialEvent(event) {
+  event.respondWith(new Promise(async (resolve, reject) => {
+    // handle request for ID and public key (typical login)
+    if(event.type === 'credentialrequest') {
+      let query = event.credentialRequestOptions.web.VerifiableProfile;
+      query = Object.assign({}, query);
+      delete query['@context'];
+      if('id' in query && 'publicKey' in query &&
+        Object.keys(query).length === 2) {
+        // cryptokey request, return verifiable profile immediately
+        return resolve({
+          dataType: 'VerifiableProfile',
+          data: {
+            '@context': 'https://w3id.org/identity/v1',
+            id: event.hintKey,
+            // TODO: add public key credential
+            // credential: ...
+          }
+        });
+      }
+    }
+
+    // handle other requests that require a UI
+    let windowClient;
+    let listener;
+    window.addEventListener('message', listener = e => {
+      if(!(e.source === windowClient &&
+        e.origin === window.location.origin)) {
+        return;
+      }
+
+      if(e.data.type === 'request') {
+        console.log('sending credential event data to UI window...');
+        // send event data to UI window
+        return windowClient.postMessage({
+          type: event.type,
+          credentialRequestOrigin: event.credentialRequestOrigin,
+          credentialRequestOptions: event.credentialRequestOptions,
+          credential: event.credential,
+          hintKey: event.hintKey
+        }, window.location.origin);
+      }
+
+      // this message is final (an error or a response)
+      window.removeEventListener('message', listener);
+
+      if(e.data.type === 'response') {
+        return resolve(e.data.credential);
+      }
+
+      // assume e.data is an error
+      // TODO: clean this up
+      reject(e.data);
+    });
+
+    try {
+      console.log('opening app window...');
+      windowClient = await event.openWindow('/' + event.type);
+      console.log('app window open, waiting for it to request event data...');
+    } catch(err) {
+      window.removeEventListener('message', listener);
+      reject(err);
+    }
+  }));
+}

--- a/vue-credential-repository/components/index.js
+++ b/vue-credential-repository/components/index.js
@@ -1,0 +1,71 @@
+/*!
+ * New BSD License (3-clause)
+ * Copyright (c) 2017-2018, Digital Bazaar, Inc.
+ * All rights reserved.
+ */
+'use strict';
+
+import * as brVue from 'bedrock-vue';
+import * as polyfill from 'credential-handler-polyfill';
+import {activate as activateHandler} from './credential-handler';
+import iconSet from 'quasar-framework/icons/fontawesome';
+import BrRoot from './BrRoot.vue';
+import CredentialRequest from './CredentialRequest.vue';
+import CredentialStore from './CredentialStore.vue';
+import Home from './Home.vue';
+import Quasar from 'quasar-framework';
+import Vue from 'vue';
+import VueRouter from 'vue-router';
+
+// install all plugins
+Vue.use(brVue);
+
+// replace default `br-root` with a custom one
+Vue.component('br-root', BrRoot);
+
+console.log('credential repository loading at ', window.location.href);
+
+const MEDIATOR_ORIGIN = window.data['authorization-io'].baseUri;
+
+brVue.setRootVue(async () => {
+  await polyfill.loadOnce(
+    MEDIATOR_ORIGIN + '/mediator?origin=' +
+    encodeURIComponent(window.location.origin));
+
+  if(window.location.pathname === '/credential-handler') {
+    // activate headless handler; do not bootstrap Vue app
+    activateHandler(MEDIATOR_ORIGIN);
+    return false;
+  }
+
+  const router = new VueRouter({
+    mode: 'history',
+    routes: [{
+      path: '/',
+      component: Home,
+      meta: {
+        title: 'Credential Repository Example'
+      }
+    }, {
+      path: '/credentialrequest',
+      component: CredentialRequest,
+      meta: {
+        title: 'Credential Wallet'
+      }
+    }, {
+      path: '/credentialstore',
+      component: CredentialStore,
+      meta: {
+        title: 'Credential Wallet'
+      }
+    }]
+  });
+
+  Quasar.icons.set(iconSet);
+  //Quasar.utils.colors.setBrand('primary', '#ffffff');
+
+  const BrApp = Vue.component('br-app');
+  return new BrApp({
+    router
+  });
+});

--- a/vue-credential-repository/configs/demo.js
+++ b/vue-credential-repository/configs/demo.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2017 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const bedrock = require('bedrock');
+const config = bedrock.config;
+const path = require('path');
+require('bedrock-server');
+require('bedrock-express');
+require('bedrock-views');
+
+// only run application on HTTP port
+bedrock.events.on('bedrock-express.ready', app => {
+  // attach express to regular http
+  require('bedrock-server').servers.http.on('request', app);
+  // cancel default behavior of attaching to HTTPS
+  return false;
+});
+
+// server info
+config.server.port = 20081;
+config.server.httpPort = 20080;
+config.server.domain = 'credential-repository.demo.digitalbazaar.com';
+config.server.host = 'credential-repository.demo.digitalbazaar.com';
+config.server.baseUri = 'https://' + config.server.host;
+
+config.views.vars.minify = true;
+
+config.express.staticOptions.maxAge = '15m';
+
+// common paths
+config.paths.cache = path.join(__dirname, '..', '.cache');
+config.paths.log = path.join('/var', 'log', 'credential-repository');
+
+// core configuration
+config.core.workers = 1;
+config.core.worker.restart = true;
+
+// master process while starting
+config.core.starting.groupId = 'adm';
+config.core.starting.userId = 'root';
+
+// master and workers after starting
+config.core.running.groupId = 'bedrock';
+config.core.running.userId = 'bedrock';
+
+// logging
+config.loggers.app.bedrock.enableChownDir = true;
+config.loggers.access.bedrock.enableChownDir = true;
+config.loggers.error.bedrock.enableChownDir = true;
+
+// configures `authorization.io` URL for DID lookup
+config['did-client']['authorization-io'].baseUrl =
+  'https://demo.authorization.io';

--- a/vue-credential-repository/demo.js
+++ b/vue-credential-repository/demo.js
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2017 Digital Bazaar, Inc. All rights reserved.
+ */
+const bedrock = require('bedrock');
+require('./lib/index');
+
+// load config
+require('./configs/demo');
+
+bedrock.start();

--- a/vue-credential-repository/dev.js
+++ b/vue-credential-repository/dev.js
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2017 Digital Bazaar, Inc. All rights reserved.
+ */
+const bedrock = require('bedrock');
+require('./lib/index');
+
+bedrock.start();

--- a/vue-credential-repository/lib/config.js
+++ b/vue-credential-repository/lib/config.js
@@ -30,6 +30,6 @@ config.paths.log = path.join(
 
 // URLs for Authorization.io
 cc('views.vars.authorization-io.baseUri', () =>
-  'https://authorization.localhost:33443');
-//  'https://demo.authorization.io');
+//  'https://authorization.localhost:33443');
+  'https://demo.authorization.io');
 //  config['did-client']['authorization-io'].baseUrl);

--- a/vue-credential-repository/lib/config.js
+++ b/vue-credential-repository/lib/config.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const bedrock = require('bedrock');
+const cc = bedrock.util.config.main.computer();
+const {config} = bedrock;
+const os = require('os');
+const path = require('path');
+require('bedrock-server');
+require('bedrock-views');
+
+// server info
+config.server.port = 14443;
+config.server.httpPort = 14080;
+config.server.domain = 'example.credential-repository.localhost';
+
+// vue-credential-repository pseudo package
+const rootPath = path.join(__dirname, '..');
+config.views.system.packages.push({
+  path: path.join(rootPath, 'components'),
+  manifest: path.join(rootPath, 'package.json')
+});
+
+// common paths
+config.paths.cache = path.resolve(path.join(rootPath, '.cache'));
+config.paths.log = path.join(
+  os.tmpdir(), 'example.credential-repository.localhost');
+
+// URLs for Authorization.io
+cc('views.vars.authorization-io.baseUri', () =>
+  'https://authorization.localhost:33443');
+//  'https://demo.authorization.io');
+//  config['did-client']['authorization-io'].baseUrl);

--- a/vue-credential-repository/lib/index.js
+++ b/vue-credential-repository/lib/index.js
@@ -1,9 +1,62 @@
 /*
- * Copyright (c) 2017 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
  */
 const bedrock = require('bedrock');
 require('bedrock-views');
 require('bedrock-webpack');
+require('bedrock-express');
+const database = require('bedrock-mongodb');
+const {promisify} = require('util');
 
 // load config
 require('./config');
+
+bedrock.events.on('bedrock-mongodb.ready', async () => {
+  await promisify(database.openCollections)(['credential']);
+
+  // TODO: make `capped` so database doesn't fill up
+  await promisify(database.createIndexes)([{
+    collection: 'credential',
+    fields: {id: 1},
+    options: {unique: true, background: false}
+  }]);
+});
+
+bedrock.events.on('bedrock-express.configure.routes', app => {
+  app.post('/credentials/:profileId', async (req, res, next) => {
+    const id = req.param('profileId');
+
+    try {
+      await database.collections.credential.update({
+        id: database.hash(id)
+      }, {
+        $set: {
+          id: database.hash(id),
+          credential: req.body
+        }
+      }, Object.assign({upsert: true}, database.writeOptions));
+    } catch(e) {
+      return next(e);
+    }
+
+    res.status(204).end();
+  });
+
+  app.get('/credentials/:profileId', async (req, res, next) => {
+    const id = req.param('profileId');
+
+    let record;
+    try {
+      record = await database.collections.credential.findOne(
+        {id: database.hash(id)}, {_id: 0, credential: 1});
+    } catch(e) {
+      return next(e);
+    }
+
+    if(!record) {
+      return res.status(404).end();
+    }
+
+    res.json(record.credential);
+  });
+});

--- a/vue-credential-repository/lib/index.js
+++ b/vue-credential-repository/lib/index.js
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2017 Digital Bazaar, Inc. All rights reserved.
+ */
+const bedrock = require('bedrock');
+require('bedrock-views');
+require('bedrock-webpack');
+
+// load config
+require('./config');

--- a/vue-credential-repository/package.json
+++ b/vue-credential-repository/package.json
@@ -11,23 +11,26 @@
   "dependencies": {
     "@fortawesome/fontawesome-free-webfonts": "^1.0.8",
     "animate.css": "^3.6.1",
+    "axios": "^0.18.0",
     "bedrock": "^1.12.1",
     "bedrock-docs": "^2.1.0",
-    "bedrock-express": "^2.0.6",
+    "bedrock-express": "^2.1.0",
+    "bedrock-mongodb": "^5.2.0",
     "bedrock-server": "^2.2.0",
     "bedrock-views": "github:digitalbazaar/bedrock-views#vue",
     "bedrock-vue": "^1.0.0",
     "bedrock-web": "^1.0.0",
     "bedrock-webpack": "digitalbazaar/bedrock-webpack#vue",
+    "credential-handler-polyfill": "^0.1.0",
+    "localforage": "^1.5.0",
     "quasar-framework": "^0.15.10",
     "vue": "^2.5.16",
-    "vue-router": "^3.0.1",
-    "credential-handler-polyfill": "^0.1.0",
-    "localforage": "^1.5.0"
+    "vue-router": "^3.0.1"
   },
   "bedrock": {
     "browserDependencies": [
       "animate.css",
+      "axios",
       "bedrock-vue",
       "credential-handler-polyfill",
       "localforage",
@@ -37,6 +40,9 @@
       "@fortawesome/fontawesome-free-webfonts"
     ],
     "manifest": {
+      "axios": {
+        "main": "dist/axios.min.js"
+      },
       "@fortawesome/fontawesome-free-webfonts": {
         "less": [
           "less/fontawesome.less",

--- a/vue-credential-repository/package.json
+++ b/vue-credential-repository/package.json
@@ -21,7 +21,7 @@
     "bedrock-vue": "^1.0.0",
     "bedrock-web": "^1.0.0",
     "bedrock-webpack": "digitalbazaar/bedrock-webpack#vue",
-    "credential-handler-polyfill": "^0.1.0",
+    "credential-handler-polyfill": "^1.0.0",
     "localforage": "^1.5.0",
     "quasar-framework": "^0.15.10",
     "vue": "^2.5.16",

--- a/vue-credential-repository/package.json
+++ b/vue-credential-repository/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "vue-credential-repository",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.js",
+  "less": "app.less",
+  "scripts": {
+    "start": "node dev.js",
+    "postinstall": "node dev.js compile-less"
+  },
+  "dependencies": {
+    "@fortawesome/fontawesome-free-webfonts": "^1.0.8",
+    "animate.css": "^3.6.1",
+    "bedrock": "^1.12.1",
+    "bedrock-docs": "^2.1.0",
+    "bedrock-express": "^2.0.6",
+    "bedrock-server": "^2.2.0",
+    "bedrock-views": "github:digitalbazaar/bedrock-views#vue",
+    "bedrock-vue": "^1.0.0",
+    "bedrock-web": "^1.0.0",
+    "bedrock-webpack": "digitalbazaar/bedrock-webpack#vue",
+    "quasar-framework": "^0.15.10",
+    "vue": "^2.5.16",
+    "vue-router": "^3.0.1",
+    "credential-handler-polyfill": "^0.1.0",
+    "localforage": "^1.5.0"
+  },
+  "bedrock": {
+    "browserDependencies": [
+      "animate.css",
+      "bedrock-vue",
+      "credential-handler-polyfill",
+      "localforage",
+      "quasar-framework",
+      "vue",
+      "vue-router",
+      "@fortawesome/fontawesome-free-webfonts"
+    ],
+    "manifest": {
+      "@fortawesome/fontawesome-free-webfonts": {
+        "less": [
+          "less/fontawesome.less",
+          "less/fa-regular.less",
+          "less/fa-solid.less"
+        ]
+      },
+      "quasar-framework": {
+        "main": "dist/umd/quasar.mat.umd.js",
+        "style": "dist/umd/quasar.mat.css"
+      }
+    }
+  },
+  "engines": {
+    "node": ">=8.9.0"
+  }
+}


### PR DESCRIPTION
This new credential repository also uses a mongo database to store credentials when the browser used is Safari (or a webkit-based browser that supports the Storage Access API). This is required because of forced third party cookie partitioning when multiple levels of iframes are used.

The entire credential demo works on Safari w/o any setting changes when using this new repository and the latest authorization.io#vue branch for the mediator. We'll need to test on iOS once we merge the related PRs and deploy. The same fixes should (in theory) work for the web payments polyfill as well.